### PR TITLE
add Vagrantfile

### DIFF
--- a/.vagrant/bootstrap.sh
+++ b/.vagrant/bootstrap.sh
@@ -1,0 +1,11 @@
+echo 'deb http://www.rabbitmq.com/debian/ testing main' |
+        sudo tee /etc/apt/sources.list.d/rabbitmq.list
+wget -O- https://www.rabbitmq.com/rabbitmq-release-signing-key.asc |
+        sudo apt-key add -
+echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+apt-get update
+apt-get install -y mongodb erlang git rabbitmq-server memcached default-jdk sbt
+git clone https://github.com/synereo/synereo.git
+chown -R vagrant\: synereo
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+#
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # create mgmt node
+  config.vm.define :synereo do |config|
+      config.vm.box = "ubuntu/trusty64"
+      config.vm.hostname = "synereo"
+      config.vm.network :private_network, ip: "10.0.15.10"
+      config.vm.provider "virtualbox" do |vb|
+        vb.memory = "2048"
+      end
+      config.vm.provision :shell, path: ".vagrant/bootstrap.sh"
+  end
+end


### PR DESCRIPTION
## Adding Vagrant Support

Using the following command:
`vagrant up`
will start an instance of Ubuntu Trusty 14.04 and install the following packages:

```
default-jdk:amd64/trusty 2:1.7-51
erlang:all/trusty-updates 1:16.b.3-dfsg-1ubuntu2.1
memcached:amd64/trusty 1.4.14-0ubuntu9
mongodb:amd64/trusty 1:2.4.9-1ubuntu2
rabbitmq-server:all/testing 3.6.5-1
sbt:all/unknown 0.13.12
```
## Prerequisites

Install [Vagrant](https://www.vagrantup.com/) and [Virtualbox](https://www.virtualbox.org/)
## Post-install

The provisoning of this machine, at the moment, take care of the environment around Synereo. You'll need to, according to the [Readme](https://github.com/thobianchi/synereo#usage):

```
vagrant ssh   # Open a shell in the virtual machine
$ cd synereo
$ sbt "gloseval/run gencert --self-signed"
```

And so on...

> Maybe is better put the command `gencert --self-signed` directly after the clone of the repo, so when the machine will come up all the Synereo software is compiled and ready.
## Test Suite

I've ran the Test Suite with good result ( even if I used a very recent pack of prerequisites ). These are some snippets:

```
[info] ScalaCheck
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[info] ScalaTest
[info] Run completed in 1 minute, 46 seconds.
[info] Total number of tests run: 70
[info] Suites: completed 12, aborted 0
[info] Tests: succeeded 70, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

```
[info] KVDBPlatformAgentMultipleDistributedTest:
[info] read
[info] - should find a results without continuation !!! IGNORED !!!
[info] Run completed in 1 minute, 4 seconds.
[info] Total number of tests run: 57
[info] Suites: completed 20, aborted 0
[info] Tests: succeeded 57, failed 0, canceled 0, ignored 85, pending 0
[info] All tests passed.
```

> Really don't know if these ignored is good or evil...

```
[info] Run completed in 1 minute, 24 seconds.
[info] Total number of tests run: 24
[info] Suites: completed 5, aborted 0
[info] Tests: succeeded 23, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error]         com.biosimilarity.evaluator.spray.AuthenticationTest
[error] (gloseval/test:test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 394 s, completed Sep 19, 2016 9:39:13 AM
```
## Issue

I came across this error:
`# SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".`
But I can't tell if is correleted to this environment or is a bug, I can't find an open issue on [Jira](https://synereo.atlassian.net/issues/?filter=-4&jql=text%20~%20%22StaticLoggerBinder%22%20order%20by%20created%20DESC)
